### PR TITLE
Potential fix for code scanning alert no. 248: Wrong number of arguments in a class instantiation

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,7 +48,7 @@ def config_dialog():
     except ImportError:
         pytest.skip("TUI main module not available")
 
-    dialog = ConfigurationDialog()
+    dialog = ConfigurationDialog(Mock(), Mock())
     dialog.app = Mock()
     dialog.app.config_manager = Mock()
     dialog.query_one = Mock()


### PR DESCRIPTION
Potential fix for [https://github.com/VoltCyclone/PCILeechFWGenerator/security/code-scanning/248](https://github.com/VoltCyclone/PCILeechFWGenerator/security/code-scanning/248)

To fix the error, we need to instantiate `ConfigurationDialog` with the correct number of required arguments. For this, we must supply at least the two required positional or keyword arguments expected by its `__init__` method. Because the code for `ConfigurationDialog` and its required parameters is not shown, we must make minimal assumptions: ideally, provide test-appropriate placeholder or mock arguments. These placeholders can be mocks (from `unittest.mock.Mock`) or reasonable dummy values (such as strings, numbers, or objects) appropriate to the parameters expected. The instantiation falls within the `config_dialog` fixture (lines 44–57), so the replacement should update line 51 to supply two dummy/mock arguments, ensuring test functionality continues without requiring specific application logic.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
