### PR TITLE
Potential fix for code scanning alert no. 150: Overly permissive file permissions

### DIFF
--- a/src/vivado_handling/vivado_runner.py
+++ b/src/vivado_handling/vivado_runner.py
@@ -146,8 +146,8 @@ echo "Vivado synthesis completed on host"
             with open(host_script, "w") as f:
                 f.write(script_content)
 
-            # Make script executable
-            os.chmod(host_script, 0o755)
+            # Make script executable (owner only)
+            os.chmod(host_script, 0o700)
 
             self.logger.info(f"Created host execution script: {host_script}")
             self.logger.info("To complete Vivado synthesis, run this on the host:")


### PR DESCRIPTION
Potential fix for [https://github.com/VoltCyclone/PCILeechFWGenerator/security/code-scanning/150](https://github.com/VoltCyclone/PCILeechFWGenerator/security/code-scanning/150)

The best way to fix this problem is to restrict the permissions on the created script file so that only the owner can read, write, and execute the script. This means changing the permission from `0o755` (`rwxr-xr-x`) to `0o700` (`rwx------`). This limits the risk of accidental or malicious access or execution by other users on the system.

To implement this:
- In `src/vivado_handling/vivado_runner.py`, locate the line that sets permissions via `os.chmod(host_script, 0o755)`
- Change the second argument to `0o700`.
- The rest of the code remains unchanged.
- No additional imports are required because `os` is already imported at the top.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
