### PR TITLE
Potential fix for code scanning alert no. 149: Overly permissive file permissions

### DIFF
--- a/vfio_check.py
+++ b/vfio_check.py
@@ -131,7 +131,7 @@ PCILeech from accessing PCI devices for firmware generation.
             with open(script_path, "w") as f:
                 f.write(script)
 
-            os.chmod(script_path, 0o755)
+            os.chmod(script_path, 0o700)
             log_info_safe(
                 logger,
                 "\n📝 Remediation script generated: {path}",


### PR DESCRIPTION
Potential fix for [https://github.com/VoltCyclone/PCILeechFWGenerator/security/code-scanning/149](https://github.com/VoltCyclone/PCILeechFWGenerator/security/code-scanning/149)

To fix this issue, you should restrict the file permissions of `vfio_remediation.sh` so that only the owner (the user running the script) can read, write, and execute the generated file. This corresponds to a file permission mask of `0o700` (rwx------). The fix is simple: change the mask argument for `os.chmod` on line 134 from `0o755` to `0o700`, making the script inaccessible to all other users on the system. This change should be made only to line 134, and no further imports or code modifications are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
